### PR TITLE
Fix GenCloud Widget

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = (
     'Orange',
     'setuptools',
     'numpy',
-    'GenAPI>=0.0.4',
+    'genesis-genapi>=1.0.1',
     # Dependencies which are problematic to install automatically
     #'openbabel-python', # You get bindings together with the openbabel library and not stand-alone
     #'scipy', # Requires Fortran compiler

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = (
     'Orange',
     'setuptools',
     'numpy',
-    'genesis-genapi>=1.0.1',
+    'genesis-genapi>=1.0.3',
     # Dependencies which are problematic to install automatically
     #'openbabel-python', # You get bindings together with the openbabel library and not stand-alone
     #'scipy', # Requires Fortran compiler


### PR DESCRIPTION
- Renamed to GenExpress
- Auto connect to dictyExpress
- Fixed download (automatically uzgzip expression files after download)
- Fixed anonymous username
- Updated annotation field names
- Display gene expression label instead of field name
- Added select server combobox (options: dictyExpress and Genialis)
- Use latest genesis-genapi from PyPI

The genapi was renamed to genesis-genapi and registered on PyPI. The module name (genapi) is the same, however. This might cause collisions in existing virtualenvs. Because the name differ, setuptools might install genesis-genapi along to the existing genapi package. Setuptools will probably not remove the existing genapi package, so you might end up with two python packages that contain modules with the same name. Please test.
