### PR TITLE
Remove workarounds when calling OWWidget.progressBarSet

### DIFF
--- a/orangecontrib/bio/widgets3/OWDatabasesUpdate.py
+++ b/orangecontrib/bio/widgets3/OWDatabasesUpdate.py
@@ -424,8 +424,6 @@ class OWDatabasesUpdate(OWWidget):
         self.domains = domains or DOMAINS
         self.serverFiles = serverfiles.ServerFiles()
 
-        self.__in_progress_update = False
-
         fbox = gui.widgetBox(self.controlArea, "Filter")
 
         # The completer model token strings
@@ -831,20 +829,11 @@ class OWDatabasesUpdate(OWWidget):
                 self._haveProgress = True
                 self.progressBarInit()
 
-            self.progressBarSet(self.progress.ratioCompleted() * 100)
-#             self.progressBarSet(self.progress.ratioCompleted() * 100,
-#                                 processEventsFlags=None)
+            self.progressBarSet(self.progress.ratioCompleted() * 100,
+                                processEvents=None)
         if rmin == rmax:
             self._haveProgress = False
             self.progressBarFinished()
-
-    def progressBarSet(self, value):
-        if not self.__in_progress_update:
-            self.__in_progress_update = True
-            try:
-                OWWidget.progressBarSet(self, value)
-            finally:
-                self.__in_progress_update = False
 
 
 class ProgressState(QObject):

--- a/orangecontrib/bio/widgets3/OWGeneInfo.py
+++ b/orangecontrib/bio/widgets3/OWGeneInfo.py
@@ -219,7 +219,6 @@ class OWGeneInfo(widget.OWWidget):
         self.selectionChangedFlag = False
 
         self.__initialized = False
-        self.__inprogressset = False
         self.initfuture = None
         self.itemsfuture = None
 
@@ -320,15 +319,8 @@ class OWGeneInfo(widget.OWWidget):
     @Slot()
     def advance(self):
         assert self.thread() is QThread.currentThread()
-        self.progressBarSet(self.progressBarValue + 1)
-
-    def progressBarSet(self, value):
-        if not self.__inprogressset:
-            self.__inprogressset = True
-            try:
-                super().progressBarSet(value)
-            finally:
-                self.__inprogressset = False
+        self.progressBarSet(self.progressBarValue + 1,
+                            processEvents=None)
 
     def initialize(self):
         if self.__initialized:


### PR DESCRIPTION
Use the new processEvents parameter to disable event loop processing.
