### PR TITLE
GEO Data Sets and Differential Expression: Fix auto commits

### DIFF
--- a/orangecontrib/bio/widgets3/OWFeatureSelection.py
+++ b/orangecontrib/bio/widgets3/OWFeatureSelection.py
@@ -1141,6 +1141,7 @@ class OWFeatureSelection(widget.OWWidget):
             cuthigh = scores_high[-max(count_high, 1)]
             cutlow = scores_low[min(count_low, len(scores_low) - 1)]
             self.histogram.setBoundary(cutlow, cuthigh)
+        self._invalidate_selection()
 
     def select_p_best(self):
         if not self.nulldist:
@@ -1164,6 +1165,7 @@ class OWFeatureSelection(widget.OWWidget):
         elif side == OWFeatureSelection.TwoTail:
             p1, p2 = np.percentile(nulldist, [100 * p / 2, 100 * (1 - p / 2)])
             self.histogram.setBoundary(p1, p2)
+        self._invalidate_selection()
 
     def _invalidate_selection(self):
         self.commit()

--- a/orangecontrib/bio/widgets3/OWFeatureSelection.py
+++ b/orangecontrib/bio/widgets3/OWFeatureSelection.py
@@ -949,6 +949,7 @@ class OWFeatureSelection(widget.OWWidget):
         self.setup_plot(self.score_index, scores, nulldist)
         self.update_data_info_label()
         self.update_selected_info_label()
+        self.commit()
 
     def setup_plot(self, scoreindex, scores, nulldist=None):
         """

--- a/orangecontrib/bio/widgets3/OWGEODatasets.py
+++ b/orangecontrib/bio/widgets3/OWGEODatasets.py
@@ -240,6 +240,7 @@ class OWGEODatasets(OWWidget):
             gui.setStopper(self, self.commitButton, cb, "selectionChanged",
                            self.commit)
         else:
+            self.commitIf = self.commit
             gui.auto_commit(self.controlArea, self, "autoCommit", "Commit",
                             box="Commit")
 

--- a/orangecontrib/bio/widgets3/OWGEODatasets.py
+++ b/orangecontrib/bio/widgets3/OWGEODatasets.py
@@ -240,9 +240,9 @@ class OWGEODatasets(OWWidget):
             gui.setStopper(self, self.commitButton, cb, "selectionChanged",
                            self.commit)
         else:
-            self.commitIf = self.commit
             gui.auto_commit(self.controlArea, self, "autoCommit", "Commit",
                             box="Commit")
+            self.commitIf = self.commit
 
         gui.rubber(self.controlArea)
 


### PR DESCRIPTION
Create schema Geo Data Sets -> Differential Expression -> GO Browser. Enable auto commit in the first two widgets. Save schema. Close Orange and reload. Auto commits are not triggered.

In Geo Data Sets, the problem is that methods call `commitIf` which probably does not play well with Orange 3's auto commit mechanism. I thus added `self.commitIf = self.commit`; this is OK since `gui.autoCommit` replaces `self.commit` with an equivalent of the Orange 2's `commitIf`.

In Differential Expression, commit was not called. I believe the proper place is in `set_scores`, but I'm not sure. @markotoplak , can you please confirm.

If this is OK, I ask for **urgent merge and upload to PyPi**.
