### PR TITLE
widgets: Ensure the correct taxonomy file is dowloaded

### DIFF
--- a/orangecontrib/bio/widgets/OWGOEnrichmentAnalysis.py
+++ b/orangecontrib/bio/widgets/OWGOEnrichmentAnalysis.py
@@ -323,7 +323,7 @@ class OWGOEnrichmentAnalysis(OWWidget):
         self.setBlocking(True)
         self._executor = ThreadExecutor()
         self._init = EnsureDownloaded(
-            [("Taxonomy", "ncbi_taxonomy.tar.gz"),
+            [(obiTaxonomy.Taxonomy.DOMAIN, obiTaxonomy.Taxonomy.FILENAME),
              ("GO", "taxonomy.pickle")]
         )
         self._init.finished.connect(self.UpdateOrganismComboBox)

--- a/orangecontrib/bio/widgets/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets/OWSetEnrichment.py
@@ -257,7 +257,7 @@ class OWSetEnrichment(OWWidget):
         self.setBlocking(True)
 
         task = EnsureDownloaded(
-            [("Taxonomy", "ncbi_taxonomy.tar.gz"),
+            [(obiTaxonomy.Taxonomy.DOMAIN, obiTaxonomy.Taxonomy.FILENAME),
              (obiGeneSets.sfdomain, "index.pck")]
         )
 

--- a/orangecontrib/bio/widgets3/OWGOEnrichmentAnalysis.py
+++ b/orangecontrib/bio/widgets3/OWGOEnrichmentAnalysis.py
@@ -297,7 +297,7 @@ class OWGOEnrichmentAnalysis(widget.OWWidget):
         self.setBlocking(True)
         self._executor = ThreadExecutor()
         self._init = EnsureDownloaded(
-            [("Taxonomy", "ncbi_taxonomy.tar.gz"),
+            [(taxonomy.Taxonomy.DOMAIN, taxonomy.Taxonomy.FILENAME),
              ("GO", "taxonomy.pickle")]
         )
         self._init.finished.connect(self.__initialize_finish)

--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -285,7 +285,7 @@ class OWSetEnrichment(widget.OWWidget):
         self.setBlocking(True)
 
         task = EnsureDownloaded(
-            [("Taxonomy", "ncbi_taxonomy.tar.gz"),
+            [(taxonomy.Taxonomy.DOMAIN, taxonomy.Taxonomy.FILENAME),
              (geneset.sfdomain, "index.pck")]
         )
 


### PR DESCRIPTION
Replace the hardcoded filenames with the proper taxonomy defined
constants.
