### PR TITLE
Add functools import for to_network to work under python 3

### DIFF
--- a/orangecontrib/bio/ontology.py
+++ b/orangecontrib/bio/ontology.py
@@ -47,6 +47,7 @@ import sys
 import re
 import warnings
 import keyword
+from functools import reduce
 from collections import defaultdict
 import six
 


### PR DESCRIPTION
This modification makes 
`OBOOntology.to_networkx(terms=["term_id1", "term_id2"])` 
work under python3. 
