### PR TITLE
compat.create_domain creates domain directly compatible with compat.create_table

### DIFF
--- a/orangecontrib/bio/dicty/__init__.py
+++ b/orangecontrib/bio/dicty/__init__.py
@@ -758,7 +758,7 @@ Can only retrieve a single result_template_type at a time"""
         cbc.end()
 
         # Restore input ids order.
-        domain = create_domain([et.domain[id] for id in ids], None, et.domain.metas if OR3 else et.domain.getmetas())
+        domain = create_domain([et.domain[id] for id in ids], None, et.domain.metas if OR3 else et.domain.getmetas().values())
         et = Orange.data.Table(domain, et)
         
         cbc = CallBack(2, optcb, callbacks=10)
@@ -1691,8 +1691,7 @@ def join_replicates(data, ignorenames=["replicate", "id", "name", "map_stop1"], 
         a.attributes.update(atdic)
         natts.append(a)
 
-
-    ndom = create_domain(natts, data.domain.class_var, data.domain.metas if OR3 else data.domain.getmetas())
+    ndom = create_domain(natts, data.domain.class_var, data.domain.metas if OR3 else data.domain.get_metas().values())
     return Orange.data.Table(ndom, data)
 
 

--- a/orangecontrib/bio/utils/compat.py
+++ b/orangecontrib/bio/utils/compat.py
@@ -26,11 +26,8 @@ def create_domain(at, cl, metas):
     else:
         domain  = Orange.data.Domain(at, cl)
         if metas:
-            if isinstance(metas, dict):
-                metas = sorted(metas.items())
-            else:
-                metas = zip([ StringVariable.new_meta_id() for _ in metas ], metas)
-            domain.add_metas(dict((StringVariable.new_meta_id(), ma) for mi, ma in metas))
+            metas = zip([ StringVariable.new_meta_id() for _ in metas ], metas)
+            domain.add_metas(dict(metas))
         return domain
 
 

--- a/orangecontrib/bio/utils/compat.py
+++ b/orangecontrib/bio/utils/compat.py
@@ -26,7 +26,9 @@ def create_domain(at, cl, metas):
     else:
         domain  = Orange.data.Domain(at, cl)
         if metas:
-            metas = zip([ StringVariable.new_meta_id() for _ in metas ], metas)
+            # add metas in the reverse order (because meta ids are always decreasing)
+            # this allows us to pass metas in the same order to create_table
+            metas = zip([ StringVariable.new_meta_id() for _ in metas ], reversed(metas))
             domain.add_metas(dict(metas))
         return domain
 
@@ -44,7 +46,7 @@ def create_table(domain, X, Y, metas):
                                 dtype=object)
         data = Orange.data.Table(domain, numpy.asarray(X), Y=Y, metas=metas)
     else:
-        metaatts = [ at for i,at in sorted(domain.getmetas().items()) ]
+        metaatts = get_metas(domain)
         insts = []
         for i in range(len(X)):
             if Y:

--- a/orangecontrib/bio/widgets/OWGenExpress.py
+++ b/orangecontrib/bio/widgets/OWGenExpress.py
@@ -807,7 +807,6 @@ class OWGenExpress(OWWidget):
                 metavars = sorted(table.domain.variables[0].attributes.keys())
                 metavars = [compat.StringVariable(name=name) for name in metavars]
                 domain = compat.create_domain(attr, None, metavars)
-                metavars = compat.get_metas(domain)
                 X = np.array([[row[exp].value for exp in experiments] for row in table])
                 metas = [[exp.attributes[var.name] for var in metavars] for exp in experiments]
                 table = compat.create_table(domain, X.transpose().tolist(), None, metas)

--- a/orangecontrib/bio/widgets3/OWGenExpress.py
+++ b/orangecontrib/bio/widgets3/OWGenExpress.py
@@ -842,7 +842,6 @@ class OWGenExpress(widget.OWWidget):
                 metavars = sorted(table.domain.variables[0].attributes.keys())
                 metavars = [compat.StringVariable.make(name) for name in metavars]
                 domain = compat.create_domain(attr, None, metavars)
-                metavars = compat.get_metas(domain)
                 metas = [[exp.attributes[var.name] for var in metavars] for exp in experiments]
                 table = compat.create_table(domain, table.X.transpose(), None, metas)
 


### PR DESCRIPTION
Changed order of meta attributes as suggested by @JakaKokosar (in Orange 2 code).

Fixes problem with GEO datasets on Orange 2 when there are multiple possible target variables and each row is a sample.