### PR TITLE
Fix a typing error in in sys.excepthook calls

### DIFF
--- a/orangecontrib/bio/widgets3/OWDatabasesUpdate.py
+++ b/orangecontrib/bio/widgets3/OWDatabasesUpdate.py
@@ -597,7 +597,7 @@ class OWDatabasesUpdate(OWWidget):
             self.SetFilesList({})
             self.retryButton.show()
         else:
-            sys.excepthook(type(exception), exception.args, None)
+            sys.excepthook(type(exception), exception, None)
             self.progress.setRange(0, 0)
             self.setEnabled(True)
 

--- a/orangecontrib/bio/widgets3/OWGeneInfo.py
+++ b/orangecontrib/bio/widgets3/OWGeneInfo.py
@@ -351,7 +351,7 @@ class OWGeneInfo(widget.OWWidget):
         self.progressBarFinished(processEvents=None)
 
     def _onInitializeError(self, exc):
-        sys.excepthook(type(exc), exc.args, None)
+        sys.excepthook(type(exc), exc, None)
         self.error(0, "Could not download the necessary files.")
 
     def _onSelectedOrganismChanged(self):


### PR DESCRIPTION
The second parameter to sys.excepthook is the exception instance
and not the exception's args (remnants of the `raise Exception, value` statement in Python 2)