### PR TITLE
[FIX] Fix errors using numpy 1.13

### DIFF
--- a/orangecontrib/bio/utils/expression.py
+++ b/orangecontrib/bio/utils/expression.py
@@ -753,12 +753,12 @@ def MA_center_lowess(G, R, f=2./3., iter=1, progressCallback=None):
     """
 #    from Bio.Statistics.lowess import lowess
     ratio, intensity = ratio_intensity(G, R)
-    valid = - (ratio.mask & intensity.mask)
+    valid = ~ (ratio.mask & intensity.mask)
     valid_ind = numpy.ma.where(valid)
     center_est = lowess(intensity[valid], ratio[valid], f=f, iter=iter, progressCallback=progressCallback)
     Gc, R = G.copy(), R.copy()
     Gc[valid] *= numpy.exp2(center_est)
-    Gc.mask, R.mask = -valid, -valid
+    Gc.mask, R.mask = ~valid, ~valid
     return Gc, R
 
 
@@ -769,7 +769,7 @@ def MA_center_lowess_fast(G, R, f=2./3., iter=1, resolution=100, progressCallbac
     """
     
     ratio, intensity = ratio_intensity(G, R)
-    valid = - (ratio.mask & intensity.mask)
+    valid = ~ (ratio.mask & intensity.mask)
     resolution = min(resolution, len(intensity[valid]))
     hist, edges = numpy.histogram(intensity[valid], len(intensity[valid])//resolution)
     
@@ -781,7 +781,7 @@ def MA_center_lowess_fast(G, R, f=2./3., iter=1, resolution=100, progressCallbac
     
     Gc, R = G.copy(), R.copy()
     Gc[valid] *= numpy.exp2(centered)
-    Gc.mask, R.mask = -valid, -valid
+    Gc.mask, R.mask = ~valid, ~valid
     return Gc, R
 
 
@@ -869,6 +869,5 @@ def MA_zscore(G, R, window=1./5., padded=False, progressCallback=None):
         if progressCallback and i % (len(sorted) // 100 + 1) == 0:
             progressCallback(100. * i / len(sorted))
         
-    z_scores._mask = - numpy.isfinite(z_scores)
+    z_scores._mask = ~numpy.isfinite(z_scores)
     return z_scores
-    

--- a/orangecontrib/bio/widgets3/OWFeatureSelection.py
+++ b/orangecontrib/bio/widgets3/OWFeatureSelection.py
@@ -1164,11 +1164,11 @@ class OWFeatureSelection(widget.OWWidget):
         assert 0 <= self.alpha_value <= 1
         p = self.alpha_value
         if side == OWFeatureSelection.HighTail:
-            cut = np.percentile(nulldist, [100 * (1 - p)])
+            cut = np.percentile(nulldist, 100 * (1 - p))
             self.max_value = cut
             self.histogram.setUpper(cut)
         elif side == OWFeatureSelection.LowTail:
-            cut = np.percentile(nulldist, [100 * p])
+            cut = np.percentile(nulldist, 100 * p)
             self.min_value = cut
             self.histogram.setLower(cut)
         elif side == OWFeatureSelection.TwoTail:
@@ -1328,13 +1328,14 @@ class Test_f_oneway(unittest.TestCase):
         np.testing.assert_almost_equal(P1, P)
 
 
-def test_main(argv=sys.argv):
+def main(argv=None):
     from AnyQt.QtWidgets import QApplication
-    app = QApplication(argv)
+    app = QApplication(list(argv) if argv else [])
+    argv = app.arguments()
     if len(argv) > 1:
         filename = argv[1]
     else:
-        filename = "brown-selected"
+        filename = "geo-gds360"
     data = Orange.data.Table(filename)
 
     w = OWFeatureSelection()
@@ -1348,4 +1349,4 @@ def test_main(argv=sys.argv):
     return rval
 
 if __name__ == "__main__":
-    sys.exit(test_main())
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
* numpy 1.13 raises an error when applying an negation operator on a boolean array.

```
------------------- TypeError Exception (in non-GUI thread) -------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWMAPlot.py", line 121, in wrapped
    return func(*args, **kwargs)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWMAPlot.py", line 394, in run
    progressCallback=lambda val: progressCallback(50 + val / 2))
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/utils/expression.py", line 872, in MA_zscore
    z_scores._mask = - numpy.isfinite(z_scores)
TypeError: The numpy boolean negative, the `-` operator, is not supported, use the `~` operator or the logical_not function instead.
```

* numpy 1.13 raises an error on indexing with non integer scalar array.
```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWFeatureSelection.py", line 1169, in select_p_best
    self.histogram.setUpper(cut)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWFeatureSelection.py", line 342, in setUpper
    self.__update_tails()
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWFeatureSelection.py", line 432, in __update_tails
    datahigh = histogram_cut(hist, edges, self.__max, edges[-1])
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWFeatureSelection.py", line 488, in histogram_cut
    cbins = bins[lowidx: highidx]
TypeError: only integer scalar arrays can be converted to a scalar index
```