### PR TITLE
[FIX] Volcano Plot: Fix selection errors on an empty widget

### DIFF
--- a/orangecontrib/bio/widgets3/OWVulcanoPlot.py
+++ b/orangecontrib/bio/widgets3/OWVulcanoPlot.py
@@ -374,7 +374,8 @@ class VolcanoGraph(pg.PlotWidget):
     def updateSelectionArea(self):
         mask = self.selectionMask()
         brush = self._stylebrush[mask.astype(int)]
-        self._item.setBrush(brush)
+        if self._item is not None:
+            self._item.setBrush(brush)
 
         if self._selitem is not None:
             self.removeItem(self._selitem)
@@ -671,15 +672,16 @@ class OWVolcanoPlot(widget.OWWidget):
 
     def on_selection_changed(self):
         # Selection area on the plot has changed.
-        mask = self.graph.selectionMask()
-        nselected = numpy.count_nonzero(mask)
-        self.infoLabel2.setText("%i selected genes" % nselected)
+        if self.data is not None:
+            mask = self.graph.selectionMask()
+            nselected = numpy.count_nonzero(mask)
+            self.infoLabel2.setText("%i selected genes" % nselected)
 
-        selection = list(self.selection())
-        # Did the selection actually change
-        if selection != self.current_selection:
-            self.current_selection = selection
-            self.commit()
+            selection = list(self.selection())
+            # Did the selection actually change
+            if selection != self.current_selection:
+                self.current_selection = selection
+                self.commit()
 
     def commit(self):
         """

--- a/orangecontrib/bio/widgets3/OWVulcanoPlot.py
+++ b/orangecontrib/bio/widgets3/OWVulcanoPlot.py
@@ -413,11 +413,11 @@ class VolcanoGraph(pg.PlotWidget):
             self.removeItem(self._item)
             self._item = None
 
-    def clear(self):
+    def clearPlot(self):
         self._item = None
         self._selitem = None
         self.plotData = numpy.empty((0, 2))
-        super().clear()
+        self.clear()
         self.selectionChanged.emit()
 
     def sizeHint(self):
@@ -506,7 +506,7 @@ class OWVolcanoPlot(widget.OWWidget):
         self.clear_graph()
 
     def clear_graph(self):
-        self.graph.clear()
+        self.graph.clearPlot()
 
     def set_data(self, data=None):
         self.closeContext()
@@ -615,7 +615,7 @@ class OWVolcanoPlot(widget.OWWidget):
             self.graph.setSelectionMode(VolcanoGraph.RectSelection)
 
     def plot(self):
-        self.graph.clear()
+        self.graph.clearPlot()
         self.validindices = numpy.empty((0,), dtype=int)
         self.current_selection = []
         group, target_indices = self.selected_split()


### PR DESCRIPTION
Fix error on selection in an empty widget.

1.) Clicking on the plot before any data is input into the widget:
```
Traceback (most recent call last):
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 347, in __on_selectionChanged
    self.updateSelectionArea()
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 377, in updateSelectionArea
    self._item.setBrush(brush)
AttributeError: 'NoneType' object has no attribute 'setBrush'
```

2.) Clicking on the plot after data was removed:
```
Traceback (most recent call last):
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 678, in on_selection_changed
    selection = list(self.selection())
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 670, in selection
    return self.validindices[mask]
IndexError: index 1778 is out of bounds for axis 1 with size 0
```