### PR TITLE
[FIX] OWSelectGenes: Fix an error in import gene names from file

### DIFF
--- a/orangecontrib/bio/widgets3/OWSelectGenes.py
+++ b/orangecontrib/bio/widgets3/OWSelectGenes.py
@@ -810,7 +810,7 @@ class OWSelectGenes(widget.OWWidget):
             self.entryField.moveCursor(QTextCursor.End)
 
     def importFromFile(self):
-        filename = QFileDialog.getOpenFileName(
+        filename, _ = QFileDialog.getOpenFileName(
             self, "Open File", os.path.expanduser("~/"))
 
         if filename:


### PR DESCRIPTION
Api incompatibility between PyQt4/5 QFileDialog.getOpenFileName