### PR TITLE
[FIX] Volcano Plot: Fix an error when one of the groups is empty

### DIFF
--- a/orangecontrib/bio/widgets3/OWVulcanoPlot.py
+++ b/orangecontrib/bio/widgets3/OWVulcanoPlot.py
@@ -716,6 +716,10 @@ class OWVolcanoPlot(widget.OWWidget):
                 # TODO: handle missing values better (mstats)
                 _, P = scipy.stats.ttest_ind(X1, X2, axis=1, equal_var=True)
                 logP = numpy.log10(P)
+                if numpy.isscalar(logP):
+                    # ttest_ind does not preserve output shape if either
+                    # a or b is empty
+                    logP = numpy.full(fold.shape, numpy.nan)
 
             mask = numpy.isfinite(fold) & numpy.isfinite(logP)
             self.validindices = numpy.flatnonzero(mask)


### PR DESCRIPTION
When one of the test groups is empty Volcano Plot widget raises an error

E.G.: 

**File** (geo-gds360.tab) -> **Data Table** (select first 10 rows) -> **Volcano Plot**

```
---------------------------- IndexError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 657, in on_target_changed
    self._update_plot()
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 665, in _update_plot
    self.plot()
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWVulcanoPlot.py", line 722, in plot
    self.graph.setPlotData(numpy.array([fold[mask], -logP[mask]]).T)
IndexError: invalid index to scalar variable.
-------------------------------------------------------------------------------
```
