### PR TITLE
[FIX] serverfiles: Pass keyword arguments through the mirrored api

### DIFF
--- a/orangecontrib/bio/utils/serverfiles.py
+++ b/orangecontrib/bio/utils/serverfiles.py
@@ -22,24 +22,24 @@ PATH = serverfile_path()
 LOCALFILES = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
 
 
-def localpath(*args):
-    return LOCALFILES.localpath(*args)
+def localpath(*args, **kwargs):
+    return LOCALFILES.localpath(*args, **kwargs)
 
     
-def listfiles(*args):
-    return [fname for domain, fname in LOCALFILES.listfiles(*args)]
+def listfiles(*args, **kwargs):
+    return [fname for domain, fname in LOCALFILES.listfiles(*args, **kwargs)]
 
 
 def localpath_download(*path, **kwargs):
     return LOCALFILES.localpath_download(*path, **kwargs)
 
 
-def download(*path):
-    return LOCALFILES.download(*path)
+def download(*args, **kwargs):
+    return LOCALFILES.download(*args, **kwargs)
 
 
-def info(*path):
-    return LOCALFILES.info(*path)
+def info(*args, **kwargs):
+    return LOCALFILES.info(*args, **kwargs)
 
 
 def update(*path, **kwargs):


### PR DESCRIPTION
Fixes an
```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWSelectGenes.py", line 1465, in _on_loadFinished
    sets = self._task.result()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/concurrent.py", line 317, in result
    return self._future.result(timeout)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/concurrent/futures/_base.py", line 398, in result
    return self.__get_result()
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/concurrent.py", line 327, in _execute
    result = self.run()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/concurrent.py", line 308, in run
    return self.function()
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWSelectGenes.py", line 1451, in load
    progress_info=progress_info)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWSelectGenes.py", line 1522, in gs_ensure_downloaded
    download_list(files, progress_info)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWSelectGenes.py", line 1535, in download_list
    callback=advance if progress_callback else None)
TypeError: download() got an unexpected keyword argument 'callback'
-------------------------------------------------------------------------------
```
error, +quite possibly more.
