### PR TITLE
[FIX] KEGG: Replace uses of obsolete links and gene sets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ cache:
   pip: true
 
 install:
-  - python -m pip install 'pip>=9'  # to install manylinux wheels
+  - python -m pip install 'pip>=9' 'setuptools>=25'
   - pip --version
+  - pip list --format=legacy
   - python setup.py clean --all sdist -d dist
   - name=$(python setup.py --name)
   - version=$(python setup.py --version)

--- a/orangecontrib/bio/kegg/api.py
+++ b/orangecontrib/bio/kegg/api.py
@@ -395,6 +395,10 @@ class CachedKeggApi(KeggApi):
         else:
             return KeggApi.get(self, ids)
 
+    @cached_method
+    def link(self, target_db, source_db=None, ids=None):
+        return KeggApi.link(self, target_db, source_db, ids)
+
     def _batch_get(self, ids):
         if len(ids) > 10:
             raise ValueError("Can batch at most 10 ids at a time.")

--- a/orangecontrib/bio/kegg/tests/test_databases.py
+++ b/orangecontrib/bio/kegg/tests/test_databases.py
@@ -86,7 +86,7 @@ class TestPathways(RemoteResourceTest):
         self.assertEqual(sorted(genes), sorted(path.genes()))
 
     def test(self):
-        self._tester("path:map00627")
+        self._tester("path:hsa05130")
 
 
 class TestUtils(unittest.TestCase):

--- a/orangecontrib/bio/widgets3/OWKEGGPathwayBrowser.py
+++ b/orangecontrib/bio/widgets3/OWKEGGPathwayBrowser.py
@@ -36,6 +36,8 @@ from .. import kegg
 from .. import geneset
 from ..utils import stats
 
+from .OWMapManOntology import relation_list_to_multimap
+
 
 def split_and_strip(string, sep=None):
     return [s.strip() for s in string.split(sep)]
@@ -673,15 +675,12 @@ class OWKEGGPathwayBrowser(widget.OWWidget):
             # We use the kegg pathway gene sets provided by 'geneset' for
             # the enrichment calculation.
 
-            # Ensure we are using the latest genesets
-            # TODO: ?? Is updating the index enough?
-            serverfiles.update(geneset.sfdomain, "index.pck")
-            kegg_gs_collections = geneset.collections(
-                (("KEGG", "pathways"), taxid)
-            )
-
+            kegg_api = kegg.api.CachedKeggApi()
+            linkmap = kegg_api.link(org.org_code, "pathway")
+            kegg_sets = relation_list_to_multimap(linkmap)
+            kegg_sets = geneset.GeneSets(input=kegg_sets)
             pathways = pathway_enrichment(
-                kegg_gs_collections, unique_genes.keys(),
+                kegg_sets, unique_genes.keys(),
                 unique_ref_genes.keys(),
                 callback=progress
             )


### PR DESCRIPTION
* Replace use of obsolete URLs for kgml download.
* Replace use of `genesets` provided gene sets in KEGGPathwayBrowser widget. KEGG can (and has) remove/replace pathways as they see fit, and the widget needs up to date list of them. So use the KEGG api to get them.

Fixes #112 and also one other error 
```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWKEGGPathwayBrowser.py", line 604, in _onPathwayTaskFinshed
    pathway_id, self.pathway = self._pathwayTask.result()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/concurrent.py", line 317, in result
    return self._future.result(timeout)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/concurrent/futures/_base.py", line 398, in result
    return self.__get_result()
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/concurrent.py", line 327, in _execute
    result = self.run()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/concurrent.py", line 308, in run
    return self.function()
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWKEGGPathwayBrowser.py", line 597, in <lambda>
    function=lambda: get_kgml_and_image(item.pathway_id)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWKEGGPathwayBrowser.py", line 592, in get_kgml_and_image
    p._get_image_filename()  # makes sure the image is downloaded
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/kegg/pathway.py", line 105, in _get_image_filename
    url = str(self.image)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/kegg/pathway.py", line 210, in image
    return self.pathway_attributes().get("image")
AttributeError: 'NoneType' object has no attribute 'get'
```