### PR TITLE
[FIX] Remove use of serverfiles global `requests.Session`

### DIFF
--- a/orangecontrib/bio/utils/serverfiles.py
+++ b/orangecontrib/bio/utils/serverfiles.py
@@ -18,8 +18,9 @@ class ServerFiles(serverfiles.ServerFiles):
     def __init__(self, server=server_url):
         serverfiles.ServerFiles.__init__(self, server)
 
+
 PATH = serverfile_path()
-LOCALFILES = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
+LOCALFILES = serverfiles.LocalFiles(PATH, )
 
 
 def localpath(*args, **kwargs):
@@ -31,19 +32,28 @@ def listfiles(*args, **kwargs):
 
 
 def localpath_download(*path, **kwargs):
-    return LOCALFILES.localpath_download(*path, **kwargs)
+    files = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
+    return files.localpath_download(*path, **kwargs)
 
 
 def download(*args, **kwargs):
-    return LOCALFILES.download(*args, **kwargs)
+    files = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
+    return files.download(*args, **kwargs)
+
+
+def allinfo(*args, **kwargs):
+    files = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
+    return files.allinfo(*args, **kwargs)
 
 
 def info(*args, **kwargs):
-    return LOCALFILES.info(*args, **kwargs)
+    files = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
+    return files.info(*args, **kwargs)
 
 
 def update(*path, **kwargs):
-    return LOCALFILES.update(*path, **kwargs)
+    files = serverfiles.LocalFiles(PATH, serverfiles=ServerFiles())
+    return files.update(*path, **kwargs)
 
 
 def sizeformat(size):


### PR DESCRIPTION
Remove global `ServerFiles` instance  and with it a global `requests.Session`. `requests.Session` objects  should not be shared between threads.