### PR TITLE
[FIX] biomart: Fix an error due to a (new?) configuration node 'MainTables'

### DIFF
--- a/orangecontrib/bio/biomart.py
+++ b/orangecontrib/bio/biomart.py
@@ -1178,9 +1178,9 @@ class ConfigurationNode(XMLNode):
         tag = node.tag
         class_ = globals().get(tag, None)
         if not class_:
-            raise ValueError("Unknown node '%s;" % tag)
-        else:
-            return class_(self.registry, tag, node.attributes, node.children)
+            class_ = ConfigurationNode
+            warnings.warn("Unknown node '%s';" % tag)
+        return class_(self.registry, tag, node.attributes, node.children)
 
     def elements(self, tag=None, **kwargs):
         if isinstance(tag, type):
@@ -1254,6 +1254,10 @@ class PushAction(ConfigurationNode):
 
 
 class MainTable(ConfigurationNode):
+    pass
+
+
+class MainTables(ConfigurationNode):
     pass
 
 

--- a/orangecontrib/bio/widgets3/OWBioMart.py
+++ b/orangecontrib/bio/widgets3/OWBioMart.py
@@ -19,14 +19,14 @@ from AnyQt.QtCore import (
     Qt, QObject, QRegExp, QModelIndex, QThread, QThreadPool, QSize,
     QStringListModel, QItemSelectionModel
 )
-from AnyQt.QtCore import Slot
+from AnyQt.QtCore import pyqtSlot as Slot
 
 import Orange
 
 from Orange.widgets.utils import concurrent
 from Orange.widgets import widget, gui, settings
 
-from .. import biomart
+from orangecontrib.bio import biomart
 
 
 def is_hidden(tree):


### PR DESCRIPTION
Most (all) mart services now return a new 'MainTables' configuration node which broke the module.

```
---------------------------- ValueError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/widgets3/OWBioMart.py", line 853, in setBioMartConfiguration
    self.registry, config.tag, config.attributes, config.children)
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/biomart.py", line 1169, in __init__
    self.children = [self._factory(child) for child in self.children]
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/biomart.py", line 1169, in <listcomp>
    self.children = [self._factory(child) for child in self.children]
  File "/Users/aleserjavec/workspace/orange-bio/orangecontrib/bio/biomart.py", line 1181, in _factory
    raise ValueError("Unknown node '%s;" % tag)
ValueError: Unknown node 'MainTables;
-------------------------------------------------------------------------------
```