### PR TITLE
[FIX] Set Enrichment: Fix filter by text

### DIFF
--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -37,8 +37,7 @@ from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.concurrent import ThreadExecutor, Task, methodinvoke
 
 from orangecontrib.bio import gene, geneset, taxonomy, utils
-# from .utils.itemmodels import FilterProxyModel
-from orangecontrib.bio.widgets3.OWMapManOntology import (
+from orangecontrib.bio.widgets3.utils.itemmodels import (
     FilterProxyModel, RealDelegate
 )
 

--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -223,7 +223,7 @@ class OWSetEnrichment(widget.OWWidget):
                       "Use entities from Reference Examples input signal " +
                       "as reference"],
             box="Reference", callback=self.updateAnnotations)
-
+        self.referenceRadioBox.setEnabled(False)
         box = gui.widgetBox(self.controlArea, "Entity Sets")
         self.groupsWidget = QTreeWidget(self)
         self.groupsWidget.setHeaderLabels(["Category"])

--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -865,8 +865,10 @@ class OWSetEnrichment(widget.OWWidget):
         header = self.annotationsChartView.header()
         for i in range(model.columnCount()):
             sh = self.annotationsChartView.sizeHintForColumn(i)
-            sh = max(sh, header.sectionSizeHint(i))
-            self.annotationsChartView.setColumnWidth(i, max(min(sh, 300), 30))
+            sh = max(header.sectionSizeHint(i), sh)
+            width = self.annotationsChartView.columnWidth(i)
+            if min(sh, 300) > width:
+                self.annotationsChartView.setColumnWidth(i, max(min(sh, 300), 30))
 
         self.progressBarFinished()
         self.setStatusMessage("")

--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -9,9 +9,13 @@ import operator
 import itertools
 import traceback
 import types
+import enum
 import concurrent.futures
+
 from collections import defaultdict
 from functools import reduce, partial
+
+from typing import List, Tuple
 
 import numpy as np
 
@@ -24,7 +28,7 @@ from AnyQt.QtGui import (
 )
 from AnyQt.QtCore import (
     Qt, QRect, QSize, QModelIndex, QStringListModel, QThread, QThreadPool,
-    Slot
+    pyqtSlot as Slot
 )
 
 import Orange
@@ -33,15 +37,17 @@ from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.concurrent import ThreadExecutor, Task, methodinvoke
 
 from orangecontrib.bio import gene, geneset, taxonomy, utils
+# from .utils.itemmodels import FilterProxyModel
+from orangecontrib.bio.widgets3.OWMapManOntology import (
+    FilterProxyModel, RealDelegate
+)
 
-from ..widgets.utils.download import EnsureDownloaded
+
+from orangecontrib.bio.widgets.utils.download import EnsureDownloaded
 
 
 def gsname(geneset):
     return geneset.name if geneset.name else geneset.id
-
-fmtp = lambda score: "%0.5f" % score if score > 10e-4 else "%0.1e" % score
-fmtpdet = lambda score: "%0.9f" % score if score > 10e-4 else "%0.5e" % score
 
 # A translation table mapping punctuation, ... to spaces
 _TR_TABLE = dict((ord(c), ord(" ")) for c in ".,!?()[]{}:;'\"<>")
@@ -52,6 +58,15 @@ def word_split(string):
     Split a string into a list of words.
     """
     return string.translate(_TR_TABLE).split()
+
+
+class FormatItemDelegate(QStyledItemDelegate):
+    def __init__(self, fmt, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__fmt = fmt
+
+    def displayText(self, value, locale):
+        return self.__fmt(value)
 
 
 class BarItemDelegate(QStyledItemDelegate):
@@ -260,7 +275,8 @@ class OWSetEnrichment(widget.OWWidget):
         fdrfilterbox.layout().setAlignment(sp, Qt.AlignLeft)
 
         self.filterLineEdit = QLineEdit(
-            self, placeholderText="Filter ...")
+            self, placeholderText="Filter ..."
+        )
 
         self.filterCompleter = QCompleter(self.filterLineEdit)
         self.filterCompleter.setCaseSensitivity(Qt.CaseInsensitive)
@@ -278,8 +294,26 @@ class OWSetEnrichment(widget.OWWidget):
             selectionMode=QTreeView.ExtendedSelection,
             rootIsDecorated=False,
             editTriggers=QTreeView.NoEditTriggers,
+            uniformRowHeights=True,
+        )
+        self.annotationsChartView.setItemDelegateForColumn(
+            ResultsModel.Pval, RealDelegate(self, precision=4)
+        )
+        self.annotationsChartView.setItemDelegateForColumn(
+            ResultsModel.FDR, RealDelegate(self, precision=4)
         )
         self.annotationsChartView.viewport().setMouseTracking(True)
+        self.proxy = FilterProxyModel(parent=self, dynamicSortFilter=True)
+
+        model = ResultsModel(parent=self)
+        self.proxy.setSourceModel(model)
+        self.annotationsChartView.setModel(self.proxy)
+        self.annotationsChartView.selectionModel().selectionChanged.connect(
+            lambda: self.commit()
+        )
+        self.annotationsChartView.header().setSortIndicator(
+            ResultsModel.Pval, Qt.AscendingOrder
+        )
         self.mainArea.layout().addWidget(self.annotationsChartView)
 
         contextEventFilter = gui.VisibleHeaderSectionContextEventFilter(
@@ -367,10 +401,6 @@ class OWSetEnrichment(widget.OWWidget):
         self.__state = self.__state & ~OWSetEnrichment.RunningEnrichment
 
         self._clearView()
-
-        if self.annotationsChartView.model() is not None:
-            self.annotationsChartView.model().clear()
-
         self.geneAttrComboBox.clear()
         self.geneAttrs = []
         self._updatesummary()
@@ -384,8 +414,10 @@ class OWSetEnrichment(widget.OWWidget):
 
     def _clearView(self):
         """Clear the enrichment report view (main area)."""
-        if self.annotationsChartView.model() is not None:
-            self.annotationsChartView.model().clear()
+        model = self.proxy.sourceModel()  # type: ResultsModel
+        model.setRowCount(0)
+        self.information(0)
+        self.warning(0)
 
     def setData(self, data=None):
         """Set the input dataset with query gene names"""
@@ -532,6 +564,7 @@ class OWSetEnrichment(widget.OWWidget):
                     not set(categories) <= set(self.currentAnnotatedCategories):
                 self.updateAnnotations()
             else:
+                self._updateFDR()
                 self.filterAnnotationsChartView()
 
     def updateGeneMatcherSettings(self):
@@ -716,9 +749,7 @@ class OWSetEnrichment(widget.OWWidget):
         self.__state &= ~OWSetEnrichment.RunningEnrichment
 
         query, reference, results = results
-
-        if self.annotationsChartView.model():
-            self.annotationsChartView.model().clear()
+        results = results  # type: List[Tuple[geneset.GeneSet, enrichment_res]]
 
         nquery = len(query)
         nref = len(reference)
@@ -734,9 +765,24 @@ class OWSetEnrichment(widget.OWWidget):
         def fmt_count(fmt, count, total):
             return fmt % (count, 100.0 * count / (total or 1))
 
-        fmt_query_count = partial(fmt_count, query_fmt)
-        fmt_ref_count = partial(fmt_count, ref_fmt)
+        fmt_query_count = partial(fmt_count, query_fmt, total=nquery)
+        fmt_ref_count = partial(fmt_count, ref_fmt, total=nref)
+        view = self.annotationsChartView
 
+        delegate = view.itemDelegateForColumn(ResultsModel.Count)
+        if delegate is not None:
+            delegate.deleteLater()
+        delegate = view.itemDelegateForColumn(ResultsModel.Reference)
+        if delegate is not None:
+            delegate.deleteLater()
+
+        view.setItemDelegateForColumn(
+            ResultsModel.Count, FormatItemDelegate(fmt_query_count, self)
+
+        )
+        view.setItemDelegateForColumn(
+            ResultsModel.Reference, FormatItemDelegate(fmt_ref_count, self)
+        )
         linkFont = QFont(self.annotationsChartView.viewOptions().font)
         linkFont.setUnderline(True)
 
@@ -752,11 +798,7 @@ class OWSetEnrichment(widget.OWWidget):
                 si.setData(value, Qt.UserRole)
             return si
 
-        model = QStandardItemModel()
-        model.setSortRole(Qt.UserRole)
-        model.setHorizontalHeaderLabels(
-            ["Category", "Term", "Count", "Reference count", "p-value",
-             "FDR", "Enrichment"])
+        model = ResultsModel(parent=self)
         for i, (gset, enrich) in enumerate(results):
             if len(enrich.query_mapped) == 0:
                 continue
@@ -766,12 +808,10 @@ class OWSetEnrichment(widget.OWWidget):
             row = [
                 item(", ".join(gset.hierarchy)),
                 item(gsname(gset), tooltip=gset.link),
-                item(fmt_query_count(nquery_mapped, nquery),
-                     tooltip=nquery_mapped, user=nquery_mapped),
-                item(fmt_ref_count(nref_mapped, nref),
-                     tooltip=nref_mapped, user=nref_mapped),
-                item(fmtp(enrich.p_value), user=enrich.p_value),
-                item(),  # column 5, FDR, is computed in filterAnnotationsChartView
+                item(nquery_mapped, tooltip=nquery_mapped, user=nquery_mapped),
+                item(nref_mapped, tooltip=nref_mapped, user=nref_mapped),
+                item(enrich.p_value, user=enrich.p_value),
+                item(np.nan),  # column 5, FDR, is computed in _updateFDR
                 item(enrich.enrichment_score,
                      tooltip="%.3f" % enrich.enrichment_score,
                      user=enrich.enrichment_score)
@@ -784,11 +824,9 @@ class OWSetEnrichment(widget.OWWidget):
 
             model.appendRow(row)
 
-        self.annotationsChartView.setModel(model)
-        self.annotationsChartView.selectionModel().selectionChanged.connect(
-            self.commit
-        )
-
+        currmodel = self.proxy.sourceModel()
+        currmodel.deleteLater()
+        self.proxy.setSourceModel(model)
         if not model.rowCount():
             self.warning(0, "No enriched sets found.")
         else:
@@ -811,21 +849,23 @@ class OWSetEnrichment(widget.OWWidget):
                             default=1)
 
             self.annotationsChartView.setItemDelegateForColumn(
-                6, BarItemDelegate(self, scale=(0.0, max_score))
+                ResultsModel.Enrichment,
+                BarItemDelegate(self, scale=(0.0, max_score))
             )
 
         self.annotationsChartView.setItemDelegateForColumn(
-            1, gui.LinkStyledItemDelegate(self.annotationsChartView)
+            ResultsModel.TermID,
+            gui.LinkStyledItemDelegate(self.annotationsChartView)
         )
+
+        self._updateFDR()
+        self.filterAnnotationsChartView()
 
         header = self.annotationsChartView.header()
         for i in range(model.columnCount()):
             sh = self.annotationsChartView.sizeHintForColumn(i)
             sh = max(sh, header.sectionSizeHint(i))
             self.annotationsChartView.setColumnWidth(i, max(min(sh, 300), 30))
-#             self.annotationsChartView.resizeColumnToContents(i)
-
-        self.filterAnnotationsChartView()
 
         self.progressBarFinished()
         self.setStatusMessage("")
@@ -833,7 +873,8 @@ class OWSetEnrichment(widget.OWWidget):
     def _updatesummary(self):
         state = self.state
         if state is None:
-            self.error(0,)
+            self.information(0)
+            self.error(0)
             self.warning(0)
             self.infoBox.setText("No data on input.\n")
             return
@@ -852,25 +893,19 @@ class OWSetEnrichment(widget.OWWidget):
             text += "<Error {}>".format(str(state.results.exception()))
         self.infoBox.setText(text)
 
-        # TODO: warn on no enriched sets found (i.e no query genes
-        # mapped to any set)
-
-    def filterAnnotationsChartView(self, filterString=""):
-        if self.__state & OWSetEnrichment.RunningEnrichment:
-            return
-
-        # TODO: Move filtering to a filter proxy model
-        # TODO: Re-enable string search
+    def _updateFDR(self):
+        # Update the FDR in place due to a changed selected categories set and
+        # results for all of these categories are already available.
+        filter = self.proxy
+        model = filter.sourceModel()
+        assert isinstance(model, ResultsModel)
 
         categories = set(", ".join(cat)
                          for cat, _ in self.selectedCategories())
 
-#         filterString = str(self.filterLineEdit.text()).lower()
-
-        model = self.annotationsChartView.model()
-
         def ishidden(index):
-            # Is item at index (row) hidden
+            # Is item at index (row) omitted from the results entirely
+            # due to belonging to a non-selected category
             item = model.item(index)
             item_cat = item.data(Qt.DisplayRole)
             return item_cat not in categories
@@ -878,39 +913,92 @@ class OWSetEnrichment(widget.OWWidget):
         hidemask = [ishidden(i) for i in range(model.rowCount())]
 
         # compute FDR according the selected categories
-        pvals = [model.item(i, 4).data(Qt.UserRole)
+        pvals = [model.item(i, ResultsModel.Pval).data(Qt.UserRole)
                  for i, hidden in enumerate(hidemask) if not hidden]
         fdrs = utils.stats.FDR(pvals)
-
-        # update FDR for the selected collections and apply filtering rules
-        itemsHidden = []
         fdriter = iter(fdrs)
-        for index, hidden in enumerate(hidemask):
-            if not hidden:
-                fdr = next(fdriter)
-                pval = model.index(index, 4).data(Qt.UserRole)
-                count = model.index(index, 2).data(Qt.ToolTipRole)
 
-                hidden = (self.useMinCountFilter and count < self.minClusterCount) or \
-                         (self.useMaxPValFilter and pval > self.maxPValue) or \
-                         (self.useMaxFDRFilter and fdr > self.maxFDR)
-
+        old = model.blockSignals(True)
+        try:
+            for index, hidden in enumerate(hidemask):
+                item = model.item(index, ResultsModel.FDR)
                 if not hidden:
-                    fdr_item = model.item(index, 5)
-                    fdr_item.setData(fmtpdet(fdr), Qt.ToolTipRole)
-                    fdr_item.setData(fmtp(fdr), Qt.DisplayRole)
-                    fdr_item.setData(fdr, Qt.UserRole)
+                    fdr = next(fdriter)
+                else:
+                    fdr = np.nan
 
-            self.annotationsChartView.setRowHidden(
-                index, QModelIndex(), hidden)
+                item.setData(fdr, Qt.DisplayRole)
+                item.setData(fdr, Qt.UserRole)
+        finally:
+            model.blockSignals(old)
 
-            itemsHidden.append(hidden)
+        model.dataChanged.emit(
+            model.index(0, ResultsModel.FDR),
+            model.index(model.rowCount() - 1, ResultsModel.FDR)
+        )
 
-        if model.rowCount() and all(itemsHidden):
+    def filterAnnotationsChartView(self):
+        if self.__state & OWSetEnrichment.RunningEnrichment:
+            return
+
+        categories = set(", ".join(cat)
+                         for cat, _ in self.selectedCategories())
+
+        filterStrings = self.filterLineEdit.text().lower().strip().split()
+
+        filter = self.proxy  # type: FilterProxyModel
+        model = filter.sourceModel()
+        assert isinstance(model, ResultsModel)
+
+        # apply filtering rules
+        filters = []
+
+        # Filter selected collections.
+        # NOTE: MUST match the condition in _updateFDR
+        filters.append(
+            FilterProxyModel.Filter(
+                ResultsModel.Category, Qt.DisplayRole,
+                lambda value: value in categories
+            )
+        )
+        if filterStrings:
+            filters.append(
+                FilterProxyModel.Filter(
+                    ResultsModel.TermID, Qt.DisplayRole,
+                    lambda value: all(fs in value.lower()
+                                      for fs in filterStrings)
+                )
+            )
+
+        if self.useMinCountFilter:
+            mincount = self.minClusterCount
+            filters.append(
+                FilterProxyModel.Filter(
+                    ResultsModel.Count, Qt.DisplayRole,
+                    lambda value: value >= mincount,
+                )
+            )
+        if self.useMaxPValFilter:
+            maxpval = self.maxPValue
+            filters.append(
+                FilterProxyModel.Filter(
+                    ResultsModel.Pval, Qt.DisplayRole,
+                    lambda value: value < maxpval
+                )
+            )
+        if self.useMaxFDRFilter:
+            maxfdr = self.maxFDR
+            filters.append(
+                FilterProxyModel.Filter(
+                    ResultsModel.FDR, Qt.DisplayRole,
+                    lambda value: value < maxfdr
+                )
+            )
+        filter.setFilters(filters)
+        if model.rowCount() and not filter.rowCount():
             self.information(0, "All sets were filtered out.")
         else:
             self.information(0)
-
         self._updatesummary()
 
     @Slot(float)
@@ -926,9 +1014,11 @@ class OWSetEnrichment(widget.OWWidget):
         if self.data is None or \
                 self.__state & OWSetEnrichment.RunningEnrichment:
             return
-
-        model = self.annotationsChartView.model()
+        proxy = self.proxy
+        model = proxy.sourceModel()
+        assert isinstance(model, ResultsModel)
         rows = self.annotationsChartView.selectionModel().selectedRows(0)
+        rows = [proxy.mapToSource(index) for index in rows]
         selected = [model.item(index.row(), 0) for index in rows]
         mapped = reduce(operator.ior,
                         (set(item.enrichment.query_mapped)
@@ -957,6 +1047,28 @@ class OWSetEnrichment(widget.OWWidget):
             self._cancelPending()
             self.state = None
         self._executor.shutdown(wait=False)
+
+
+class ResultsModel(QStandardItemModel):
+    class Column(enum.IntEnum):
+        Category, TermID, Count, Reference, Pval, FDR, Enrichment = range(7)
+    Category, TermID, Count, Reference, Pval, FDR, Enrichment = Column
+
+    HeaderLabels = [
+        (Category, "Category"),
+        (TermID, "Term"),
+        (Count, "Count"),
+        (Reference, "Reference count"),
+        (Pval, "p-value"),
+        (FDR, "FDR"),
+        (Enrichment, "Enrichment")
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setHorizontalHeaderLabels(
+            [name for _, name in self.HeaderLabels]
+        )
 
 
 class UserInteruptException(Exception):
@@ -999,15 +1111,23 @@ def set_enrichment(target, reference, query,
     )
 
 
-if __name__ == "__main__":
-    app = QApplication(sys.argv)
+def main(argv=None):
+    app = QApplication(argv or [])
+    argv = app.arguments()
+    if len(argv) > 1:
+        filename = argv[1]
+    else:
+        filename = "brown-selected"
+
     w = OWSetEnrichment()
-#     data = Orange.data.Table("yeast-class-RPR.tab")
-    data = Orange.data.Table("brown-selected")
+    data = Orange.data.Table(filename)
     w.setData(data)
-#     w.setReference(data)
     w.handleNewSignals()
     w.show()
     app.exec_()
     w.saveSettings()
     w.onDeleteWidget()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -818,9 +818,10 @@ class OWSetEnrichment(widget.OWWidget):
             ]
             row[0].geneset = gset
             row[0].enrichment = enrich
-            row[1].setData(gset.link, gui.LinkRole)
-            row[1].setFont(linkFont)
-            row[1].setForeground(QColor(Qt.blue))
+            if gset.link:
+                row[1].setData(gset.link, gui.LinkRole)
+                row[1].setFont(linkFont)
+                row[1].setForeground(QColor(Qt.blue))
 
             model.appendRow(row)
 

--- a/orangecontrib/bio/widgets3/OWSetEnrichment.py
+++ b/orangecontrib/bio/widgets3/OWSetEnrichment.py
@@ -251,7 +251,7 @@ class OWSetEnrichment(widget.OWWidget):
             callback=self.filterAnnotationsChartView,
             callbackOnReturn=True,
         )
-        sp.setEnabled(self.useMaxFDRFilter)
+        sp.setEnabled(self.useMaxPValFilter)
         cb.toggled[bool].connect(sp.setEnabled)
 
         pvalfilterbox.layout().setAlignment(cb, Qt.AlignRight)

--- a/orangecontrib/bio/widgets3/utils/itemmodels.py
+++ b/orangecontrib/bio/widgets3/utils/itemmodels.py
@@ -1,0 +1,69 @@
+import numbers
+from collections import namedtuple
+from typing import Sequence
+
+from AnyQt.QtCore import Qt, QSortFilterProxyModel
+from AnyQt.QtWidgets import QStyledItemDelegate
+
+
+class FilterProxyModel(QSortFilterProxyModel):
+    """
+    A simple filter proxy model with settable filter predicates
+
+    Example
+    -------
+    >>> proxy = FilterProxyModel()
+    >>> proxy.setFilters([
+    ...     FilterProxyModel.Filter(0, Qt.DisplayRole, lambda value: value < 1)
+    ... ])
+    """
+    Filter = namedtuple("Filter", ["column", "role", "predicate"])
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__filters = []
+
+    def setFilters(self, filters):
+        # type: (Sequence[FilterProxyModel.Filter]) -> None
+        filters = [FilterProxyModel.Filter(f.column, f.role, f.predicate)
+                   for f in filters]
+        self.__filters = filters
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, row, parent):
+        source = self.sourceModel()
+
+        def apply(f):
+            index = source.index(row, f.column, parent)
+            data = source.data(index, f.role)
+            try:
+                return f.predicate(data)
+            except (TypeError, ValueError):
+                return False
+
+        return all(apply(f) for f in self.__filters)
+
+
+class RealDelegate(QStyledItemDelegate):
+    """
+    An Item delegate for displaying numerical columns
+    """
+    def __init__(self, parent=None, precision=4, **kwargs):
+        super().__init__(parent, **kwargs)
+        self.precision = precision
+
+    def displayText(self, value, locale):
+        if isinstance(value, numbers.Integral):
+            return locale.toString(int(value))
+        elif isinstance(value, numbers.Real):
+            return locale.toString(float(value), "g", self.precision)
+        else:
+            return super().displayText(value, locale)
+
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+        align = index.data(Qt.TextAlignmentRole)
+        data = index.data(Qt.DisplayRole)
+        if align is None and isinstance(data, numbers.Real):
+            # Right align if the model does not specify otherwise
+            option.displayAlignment = Qt.AlignRight | Qt.AlignVCenter


### PR DESCRIPTION
##### Issue

The text search/filter in 'Set Enrichment' widget does nothing (and has done so for roughly 4 years).

Alternative to gh-119

##### Description of changes

* Use the 'FilterProxyModel' (extracted from OWMapManOntology) to abstract all the filtering including text filter.

While here also:

* Fix styling of set names that do not have an associated url link.
* Fix widget initialization (enabled disabled state for *'p-value'* filter and *'Reference'* box
* Store/restore the user changed header state

