### PR TITLE
Add support for BRITE field

### DIFF
--- a/orangecontrib/bio/kegg/databases.py
+++ b/orangecontrib/bio/kegg/databases.py
@@ -408,6 +408,7 @@ class GeneEntry(entry.DBEntry):
         ("ORGANISM", fields.DBSimpleField),
         ("PATHWAY", fields.DBPathway),
         ("MODULE", fields.DBSimpleField),
+        ("BRITE", fields.DBSimpleField),
         ("DISEASE", fields.DBSimpleField),
         ("DRUG_TARGET", fields.DBSimpleField),
         ("CLASS", fields.DBSimpleField),


### PR DESCRIPTION
Before, parsing a gene entry via GeneEntry(text) would return the following warning:
orangecontrib/bio/kegg/entry/__init__.py:136: UserWarning: Nonregisterd field 'BRITE' in <class 'orangecontrib.bio.kegg.databases.GeneEntry'>
  (title, type(self)))