### PR TITLE
[FIX] OWFeatureSelection: Fix check for group non representation

### DIFF
--- a/orangecontrib/bio/widgets3/OWFeatureSelection.py
+++ b/orangecontrib/bio/widgets3/OWFeatureSelection.py
@@ -848,7 +848,7 @@ class OWFeatureSelection(widget.OWWidget):
         else:
             assert False
 
-        if not all(np.count_nonzero(ind) > 0 for ind in indices):
+        if not all(ind.size > 0 for ind in indices):
             self.error(0, "Target labels most exclude/include at least one "
                           "value.")
             self.scores = None


### PR DESCRIPTION
#### Issue

OWFeatureSelection (*Differential Expression*) has a wrong check for group non-representation. It seems to assume indices are bool arrays when in fact they are int arrays.

#### Fix

Check the size of the index arrays.



